### PR TITLE
correct license name

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -18,7 +18,7 @@
 
     <licenses>
         <license>
-            <name>gpl</name>
+            <name>GNU General Public License v2.0 only, with Classpath exception</name>
             <url>http://openjdk.java.net/legal/gplv2+ce.html</url>
             <distribution>repo</distribution>
         </license>


### PR DESCRIPTION
"gpl" is ambiguous, this artifact is consumed by WildFly and we rely on an unambiguous name being provided.